### PR TITLE
Use the correct form of `sha256.Sum224`.

### DIFF
--- a/internal/encryption/aes.go
+++ b/internal/encryption/aes.go
@@ -56,7 +56,8 @@ func Decrypt(data, password []byte) ([]byte, error) {
 func deriveKey(password []byte) []byte {
 	buf := make([]byte, 32) // Will use AES-256
 
-	copy(buf, sha256.New224().Sum(password)) // Fill the rest of the hash with zeros (SHA-224 leads to a 28 byte long hash)
+	h := sha256.Sum224(password)
+	copy(buf, h[:]) // Fill the rest of the hash with zeros (SHA-224 leads to a 28 byte long hash)
 
 	return buf
 }


### PR DESCRIPTION
`sha256.New224().Sum(foo)` appends the SHA-224 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk (SHA256 but same concept).

