### PR TITLE
feat: Add ability to avoid announcing interfaces or ips

### DIFF
--- a/cmd/weron/cmd/chat.go
+++ b/cmd/weron/cmd/chat.go
@@ -175,6 +175,8 @@ func init() {
 	chatCmd.PersistentFlags().StringSlice(iceFlag, []string{"stun:stun.l.google.com:19302"}, "Comma-separated list of STUN servers (in format stun:host:port) and TURN servers to use (in format username:credential@turn:host:port) (i.e. username:credential@turn:global.turn.twilio.com:3478?transport=tcp)")
 	chatCmd.PersistentFlags().Bool(forceRelayFlag, false, "Force usage of TURN servers")
 	chatCmd.PersistentFlags().Duration(kicksFlag, time.Second*5, "Time to wait for kicks")
+	chatCmd.PersistentFlags().String(excludeInterfacePrefixFlag, "", "Comma-separated, Case-sensitive list of prefixes to exclude from interface names (i.e. \"vEthernet\" matches \"vEthernet_direct\" but not \"vethernet\")")
+	chatCmd.PersistentFlags().String(excludeInterfaceIpFlag, "", "Comma-separated list of IPs or IP CIDR to exclude from connecting with (i.e. \"100.64.0.0/24,100.65.0.1\")")
 
 	viper.AutomaticEnv()
 

--- a/cmd/weron/cmd/utility_latency.go
+++ b/cmd/weron/cmd/utility_latency.go
@@ -148,6 +148,8 @@ func init() {
 	utilityLatencyCommand.PersistentFlags().Bool(serverFlag, false, "Act as a server")
 	utilityLatencyCommand.PersistentFlags().Int(packetLengthFlag, 128, "Size of packet to send and acknowledge")
 	utilityLatencyCommand.PersistentFlags().Duration(pauseFlag, time.Second*1, "Time to wait before sending next packet")
+	utilityLatencyCommand.PersistentFlags().String(excludeInterfacePrefixFlag, "", "Comma-separated, Case-sensitive list of prefixes to exclude from interface names (i.e. \"vEthernet\" matches \"vEthernet_direct\" but not \"vethernet\")")
+	utilityLatencyCommand.PersistentFlags().String(excludeInterfaceIpFlag, "", "Comma-separated list of IPs or IP CIDR to exclude from connecting with (i.e. \"100.64.0.0/24,100.65.0.1\")")
 
 	viper.AutomaticEnv()
 

--- a/cmd/weron/cmd/utility_throughput.go
+++ b/cmd/weron/cmd/utility_throughput.go
@@ -164,6 +164,8 @@ func init() {
 	utilityThroughputCmd.PersistentFlags().Bool(serverFlag, false, "Act as a server")
 	utilityThroughputCmd.PersistentFlags().Int(packetLengthFlag, 50000, "Size of packet to send")
 	utilityThroughputCmd.PersistentFlags().Int(packetCountFlag, 1000, "Amount of packets to send before waiting for acknowledgement")
+	utilityThroughputCmd.PersistentFlags().String(excludeInterfacePrefixFlag, "", "Comma-separated, Case-sensitive list of prefixes to exclude from interface names (i.e. \"vEthernet\" matches \"vEthernet_direct\" but not \"vethernet\")")
+	utilityThroughputCmd.PersistentFlags().String(excludeInterfaceIpFlag, "", "Comma-separated list of IPs or IP CIDR to exclude from connecting with (i.e. \"100.64.0.0/24,100.65.0.1\")")
 
 	viper.AutomaticEnv()
 

--- a/cmd/weron/cmd/vpn_ethernet.go
+++ b/cmd/weron/cmd/vpn_ethernet.go
@@ -16,9 +16,11 @@ import (
 )
 
 const (
-	devFlag      = "dev"
-	macFlag      = "mac"
-	parallelFlag = "parallel"
+	devFlag                    = "dev"
+	macFlag                    = "mac"
+	parallelFlag               = "parallel"
+	excludeInterfacePrefixFlag = "exclude-interface-prefix"
+	excludeInterfaceIpFlag     = "exclude-interface-ip"
 )
 
 var vpnEthernetCmd = &cobra.Command{
@@ -110,6 +112,8 @@ func init() {
 	vpnEthernetCmd.PersistentFlags().String(devFlag, "", "Name to give to the TAP device (i.e. weron0) (default is auto-generated; only supported on Linux and macOS)")
 	vpnEthernetCmd.PersistentFlags().String(macFlag, "", "MAC address to give to the TAP device (i.e. 3a:f8:de:7b:ef:52) (default is auto-generated; only supported on Linux)")
 	vpnEthernetCmd.PersistentFlags().Int(parallelFlag, runtime.NumCPU(), "Amount of threads to use to decode frames")
+	vpnEthernetCmd.PersistentFlags().String(excludeInterfacePrefixFlag, "", "Comma-separated, Case-sensitive list of prefixes to exclude from interface names (i.e. \"vEthernet\" matches \"vEthernet_direct\" but not \"vethernet\")")
+	vpnEthernetCmd.PersistentFlags().String(excludeInterfaceIpFlag, "", "Comma-separated list of IPs or IP CIDR to exclude from connecting with (i.e. \"100.64.0.0/24,100.65.0.1\")")
 
 	viper.AutomaticEnv()
 

--- a/cmd/weron/cmd/vpn_ip.go
+++ b/cmd/weron/cmd/vpn_ip.go
@@ -137,6 +137,8 @@ func init() {
 	vpnIPCmd.PersistentFlags().String(idChannelFlag, services.IPID, "Channel to use to negotiate names")
 	vpnIPCmd.PersistentFlags().Duration(kicksFlag, time.Second*5, "Time to wait for kicks")
 	vpnIPCmd.PersistentFlags().Int(maxRetriesFlag, 200, "Maximum amount of times to try and claim an IP address")
+	vpnIPCmd.PersistentFlags().String(excludeInterfacePrefixFlag, "", "Comma-separated, Case-sensitive list of prefixes to exclude from interface names (i.e. \"vEthernet\" matches \"vEthernet_direct\" but not \"vethernet\")")
+	vpnIPCmd.PersistentFlags().String(excludeInterfaceIpFlag, "", "Comma-separated list of IPs or IP CIDR to exclude from connecting with (i.e. \"100.64.0.0/24,100.65.0.1\")")
 
 	viper.AutomaticEnv()
 

--- a/pkg/wrtcconn/adapter.go
+++ b/pkg/wrtcconn/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/url"
 	"strings"
 	"sync"
@@ -15,6 +16,12 @@ import (
 	websocketapi "github.com/pojntfx/weron/internal/api/websocket"
 	"github.com/pojntfx/weron/internal/encryption"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+)
+
+const (
+	excludeInterfacePrefixFlag = "exclude-interface-prefix"
+	excludeInterfaceIpFlag     = "exclude-interface-ip"
 )
 
 var (
@@ -62,6 +69,8 @@ type Adapter struct {
 	peers chan *Peer
 
 	api *webrtc.API
+
+	excludedIPs []*net.IPNet // Collected IP addresses from excluded interface
 }
 
 // NewAdapter creates the adapter
@@ -94,6 +103,8 @@ func NewAdapter(
 		cancel: cancel,
 		peers:  make(chan *Peer),
 		lines:  make(chan []byte),
+
+		excludedIPs: make([]*net.IPNet, 0),
 	}
 }
 
@@ -108,9 +119,103 @@ func (a *Adapter) sendLine(line []byte) {
 	a.lines <- line
 }
 
+func (a *Adapter) CollectExcludedInterfaceIPs(interfaceName string) {
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		if iface.Name == interfaceName {
+			addrs, _ := iface.Addrs()
+			for _, addr := range addrs {
+				if ipnet, ok := addr.(*net.IPNet); ok {
+					a.excludedIPs = append(a.excludedIPs, ipnet)
+				}
+			}
+		}
+	}
+}
+
+func (a *Adapter) IsCandidateExcluded(candidateContent string) bool {
+	fields := strings.Fields(candidateContent)
+	if len(fields) < 5 {
+		return false
+	}
+
+	ipStr := fields[4]
+	candidateIP := net.ParseIP(ipStr)
+	if candidateIP == nil {
+		return false
+	}
+
+	for _, ipnet := range a.excludedIPs {
+		if ipnet.Contains(candidateIP) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Open connects the adapter to the signaler
 func (a *Adapter) Open() (chan string, error) {
+	interfaceIps := viper.GetString(excludeInterfaceIpFlag)
+	if interfaceIps != "" {
+		ipStrings := strings.Split(interfaceIps, ",")
+		for _, s := range ipStrings {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+
+			_, ipNet, err := net.ParseCIDR(s)
+			if err == nil {
+				a.excludedIPs = append(a.excludedIPs, ipNet)
+				continue
+			}
+
+			ip := net.ParseIP(s)
+			if ip != nil {
+				mask := net.CIDRMask(8*len(ip.To4()), 8*len(ip.To4()))
+				if ip.To4() == nil {
+					mask = net.CIDRMask(128, 128)
+				}
+				singleNet := &net.IPNet{IP: ip, Mask: mask}
+				a.excludedIPs = append(a.excludedIPs, singleNet)
+			}
+		}
+	}
+
 	settingEngine := webrtc.SettingEngine{}
+	interfacePrefixes := viper.GetString(excludeInterfacePrefixFlag)
+	if interfacePrefixes != "" {
+		prefixes := strings.Split(interfacePrefixes, ",")
+		ifaces, _ := net.Interfaces()
+		for _, iface := range ifaces {
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(iface.Name, strings.TrimSpace(prefix)) {
+					a.CollectExcludedInterfaceIPs(iface.Name)
+				}
+			}
+		}
+	}
+	if interfacePrefixes != "" {
+		prefixes := strings.Split(interfacePrefixes, ",")
+
+		settingEngine.SetInterfaceFilter(func(interfaceName string) bool {
+			for _, prefix := range prefixes {
+				prefix = strings.TrimSpace(prefix)
+				if prefix == "" {
+					continue
+				}
+
+				matched := strings.HasPrefix(interfaceName, prefix)
+				if matched {
+					return false
+				}
+			}
+
+			return true
+		})
+	}
+
 	settingEngine.DetachDataChannels()
 	a.api = webrtc.NewAPI(webrtc.WithSettingEngine(settingEngine))
 
@@ -722,6 +827,19 @@ func (a *Adapter) Open() (chan string, error) {
 
 							go func() {
 								for candidate := range candidates {
+									candidateContent := candidate.Candidate
+									isDiscarded := a.IsCandidateExcluded(candidateContent)
+									if isDiscarded {
+										log.Debug().
+											Str("address", conn.RemoteAddr().String()).
+											Str("community", community).
+											Str("id", id).
+											Str("peerID", offer.From).
+											Msg("ICE candidate from signaler has been discarded due to exclusion rules")
+
+										continue
+									}
+
 									if err := c.AddICECandidate(candidate); err != nil {
 										errs <- err
 
@@ -849,6 +967,19 @@ func (a *Adapter) Open() (chan string, error) {
 
 							go func() {
 								for candidate := range c.candidates {
+									candidateContent := candidate.Candidate
+									isDiscarded := a.IsCandidateExcluded(candidateContent)
+									if isDiscarded {
+										log.Debug().
+											Str("address", conn.RemoteAddr().String()).
+											Str("community", community).
+											Str("id", id).
+											Str("peerID", answer.From).
+											Msg("ICE candidate from signaler has been discarded due to exclusion rules")
+
+										continue
+									}
+
 									if err := c.conn.AddICECandidate(candidate); err != nil {
 										errs <- err
 


### PR DESCRIPTION
#### Main content
- feat: Allow user to set which interface's ips NOT to send to another peer through signaler and connect with using FLAG "--exclude-interface-prefix"; allow user set which ips NOT to connect with when host received the ICE candidate using FLAG "--exclude-interface-ip". This commit aims to resolve issues with weron tunnels running in other Virtual tunnels(i.e. Tailscale, ZeroTier or EasyTile etc.

---

#### PS
- Sorry, It's my first time programming with GO and contributing, with AI, I have tested it on Windows 11, plz tell me if any issues happend! Thank you, I'm so glad to be working on this project with everyone~